### PR TITLE
docs: translate documentation to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# automatic-qa-tool
-Tool to run automated QA tests on any website.
+# Automated QA Tooling with GitHub Actions
+
+![QA automation banner](https://placehold.co/1200x400/1e293b/ffffff?text=QA%20Automation%20Pipeline&font=inter)
+
+This repository provides a Continuous Integration pipeline built on GitHub Actions that runs a set of automated quality checks against any website.
+
+It delivers fast, consistent analysis across four key areas: **Performance, Accessibility, Basic Security, and WordPress-specific Vulnerabilities.**
+
+## ✨ Key Features
+
+* **⚡ Performance Testing (Lighthouse):** Measures core performance, SEO, and best practice metrics.
+* **♿ Accessibility Testing (Pa11y + Axe):** Scans for WCAG violations.
+* **🛡️ Basic Security Testing (OWASP ZAP):** Detects passive and low-risk security issues.
+* **🔎 WordPress Vulnerability Testing (WPScan):** Identifies known issues when a site runs WordPress.
+
+## 🚀 Get Started
+
+For architecture details, setup instructions, and usage information, see the documentation in `/docs`.
+
+* **[Implementation Guide](./docs/2_IMPLEMENTATION_GUIDE.md)** – Set up the tool from scratch.
+* **[Usage Guide](./docs/3_USAGE.md)** – Run the checks once configured.

--- a/docs/1_ARCHITECTURE.md
+++ b/docs/1_ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# 1. System Architecture
+
+The solution has two main parts that can work together or independently to provide a complete QA system.
+
+### The Architect (Custom GPT)
+A conversational assistant used for **planning and strategy**. Responsibilities:
+
+* Generate detailed test plans.
+* Draft use cases and acceptance criteria.
+* Prototype and write initial code for CI workflows such as the one used here.
+
+### The Executor (GitHub Actions Workflow)
+A set of automated "robots" that live in the repository and handle the **repetitive work and technical execution**. Responsibilities:
+
+* Accept a URL as input.
+* Run the four technical analyses in parallel (Lighthouse, Pa11y, ZAP, WPScan).
+* Report results directly in the GitHub Actions run logs.

--- a/docs/2_IMPLEMENTATION_GUIDE.md
+++ b/docs/2_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,29 @@
+# 2. Implementation Guide (Step by Step)
+
+Follow these steps to implement the tool.
+
+### Prerequisites
+You only need two things:
+
+1. A free **GitHub account**.
+2. A free **WPScan API token**, available at [wpscan.com/api](https://wpscan.com/api).
+
+### Setup Steps
+
+**1. Create the repository:**
+* Create a new repository on GitHub.
+* **Make it Public** to take advantage of free runner minutes.
+* Initialize it with a `README.md` file.
+
+**2. Create the workflow file:**
+* In the repository, create this folder and file structure: `.github/workflows/main-test-workflow.yml`.
+* Paste the workflow content into that file.
+
+**3. Configure secrets and variables:**
+* Go to `Settings` > `Secrets and variables` > `Actions`.
+* Under **Secrets**, create a new secret:
+    * **Name:** `WPSCAN_API_TOKEN`
+    * **Value:** paste your WPScan API token.
+* Under **Variables**, create a new variable:
+    * **Name:** `BASE_URL`
+    * **Value:** the website URL to test (e.g., `https://your-site.com`).

--- a/docs/3_USAGE.md
+++ b/docs/3_USAGE.md
@@ -1,0 +1,16 @@
+# 3. Usage Guide
+
+Once configured, the tool is straightforward to use.
+
+### Run the Checks
+1. Go to the **Actions** tab of your repository.
+2. Select the **QA Test General** workflow in the sidebar.
+3. Click **Run workflow**.
+
+The logs and results for each of the four checks appear in the run summary.
+
+### Test a Different Website
+To test another site:
+1. Navigate to `Settings` > `Secrets and variables` > `Actions` > `Variables`.
+2. **Update the `BASE_URL` value** with the new address.
+3. Return to the Actions tab and run the workflow again.

--- a/docs/4_EXPANSION.md
+++ b/docs/4_EXPANSION.md
@@ -1,0 +1,23 @@
+# 4. Expansion & Considerations
+
+### Tool Expansion
+The tool is built to be extensible. Because it relies on GitHub Actions, the possibilities are almost unlimited. Potential enhancements include:
+
+* **Add new types of checks:**
+    * A broken link checker (`lychee-link-checker`).
+    * Visual regression tests to catch unexpected UI changes.
+    * HTML/CSS validation tests.
+* **Improve notifications:**
+    * Set up a bot to post summaries to **Slack** or **Discord**.
+    * Send an email report after the checks finish.
+* **Integrate with GPT (Phase 3):**
+    * Create GPT "Actions" that can trigger this workflow and read results via the GitHub API, enabling full control from a conversational interface.
+* **Advanced multipage testing:**
+    * Modify the workflow to accept a list of URLs and run the checks across all of them, not just predefined ones.
+
+### Cost & Security Considerations
+* **Cost:** The tool is **100% free** as long as the repository is public.
+* **Security:**
+    * `WPSCAN_API_TOKEN` is stored securely using GitHub Secrets.
+    * The workflow uses read-only permissions (`contents: read`) to follow the principle of least privilege.
+    * The WPScan free tier allows 25 requests per day; the API automatically blocks requests beyond that limit, preventing any charges.


### PR DESCRIPTION
## Summary
- translate README and docs to American English
- clarify architecture, implementation steps, usage, and expansion sections

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `pytest` *(fails: /usr/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68b89090fa0c8331b6e08c60017d6a0f