### PR TITLE
Add docs generation scripts and setup guide

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -1,0 +1,80 @@
+# Local Development Environment & Tooling
+
+This guide outlines the minimal tooling required to generate the aggregated documentation artifacts used by this repository:
+
+- **Full Code Reference** → `npm run docs:code:regen`
+- **Full Docs Reference** → `npm run docs:docs:regen`
+
+> **Note:** Database export artifacts (e.g., `full_database_reference.md`) are **not part of this repository’s workflow**. They are only applicable in other projects. See **Optional database prerequisites** below.
+
+## Requirements
+
+- **Node.js v18 or newer** available on your PATH.
+- A working shell (bash/zsh/PowerShell) with permission to install developer tools.
+
+## Install Node.js (choose one path)
+
+### macOS (Homebrew)
+```bash
+brew install node@18
+echo 'export PATH="$(brew --prefix)/opt/node@18/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+node -v
+```
+
+### Linux (nvm)
+```bash
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 18
+nvm use 18
+node -v
+```
+
+### Windows (winget)
+```powershell
+winget install OpenJS.NodeJS.LTS
+node -v
+```
+
+## After cloning the repository
+
+Once the scripts are present in `package.json`:
+
+```bash
+npm run docs:code:regen
+npm run docs:docs:regen
+```
+
+These commands (re)generate:
+- `docs/full_code_reference.md`
+- `docs/full_docs_reference.md`
+
+## Optional database prerequisites (only if applicable in another project)
+
+If you later enable a **database reference** workflow (not part of this repository), you will typically need:
+
+- Node package:
+```bash
+npm i dotenv
+```
+
+- PostgreSQL client tools (for `pg_dump`):
+  - **macOS (Homebrew)**
+    ```bash
+    brew install libpq
+    echo 'export PATH="$(brew --prefix)/opt/libpq/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+    ```
+  - **Ubuntu/Debian**
+    ```bash
+    sudo apt-get update && sudo apt-get install -y postgresql-client
+    ```
+  - **Windows**
+    - Install PostgreSQL or the standalone client tools and add the `bin` directory (containing `pg_dump`) to your **PATH**.
+
+> In that scenario, the script would read `DATABASE_URL` from `.env` via `dotenv`. **Do not implement or document that script here.**
+
+## Troubleshooting
+
+- `node: command not found` → Ensure Node.js is installed and present on your PATH.
+- Permission errors on macOS/Linux → Re-run the install commands, then `source` your shell profile (e.g., `~/.zshrc`).
+- Windows PATH issues → Close and reopen the terminal after installing Node.js or PostgreSQL tools.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspace",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "docs:code:regen": "node scripts/generate_full_code_reference.mjs",
+    "docs:docs:regen": "node scripts/generate_full_docs_reference.mjs"
+  }
+}

--- a/scripts/generate_full_code_reference.mjs
+++ b/scripts/generate_full_code_reference.mjs
@@ -1,0 +1,88 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+// Directories/files to include
+const includeDirs = ["src", "server", "tests", "lib", "scripts"];
+const includeFiles = ["uno.config.js", "vite.config.js", "package.json"];
+const binaryExts = [
+  ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".pdf", ".zip", ".ico",
+  ".ttf", ".otf", ".woff", ".woff2", ".map", ".jar", ".exe", ".dylib"
+];
+
+function isExcludedDir(rel) {
+  const segs = rel.split(path.sep);
+  return ["node_modules", ".vercel", "dist", "build", ".temp", ".cache", ".git"]
+    .some((e) => segs.includes(e));
+}
+
+function isBinary(file) {
+  return binaryExts.includes(path.extname(file).toLowerCase());
+}
+
+async function collect(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    const rel = path.relative(root, full);
+    if (isExcludedDir(rel)) continue;
+    if (entry.isDirectory()) {
+      files.push(...(await collect(full)));
+    } else if (!isBinary(entry.name) && !entry.name.endsWith(".lock")) {
+      const inDir = includeDirs.some((d) => rel.startsWith(d + path.sep));
+      const isFile =
+        includeFiles.includes(rel) ||
+        (rel.startsWith("tsconfig") && rel.endsWith(".json"));
+      if (inDir || isFile) files.push(rel);
+    }
+  }
+  return files;
+}
+
+function fenceFor(file) {
+  const ext = path.extname(file).slice(1).toLowerCase();
+  const map = { mjs: "js", cjs: "js", yml: "yaml" };
+  return map[ext] ?? (ext || "text");
+}
+
+async function main() {
+  const outFile = path.join(root, "docs/full_code_reference.md");
+  await fs.mkdir(path.dirname(outFile), { recursive: true });
+  const files = (await collect(root)).sort();
+
+  // Load existing sections to minimize diffs
+  let existingSections = new Map();
+  try {
+    const existing = await fs.readFile(outFile, "utf8");
+    const regex = /^### (.+?)\n\n```[\s\S]*?\n```\n\n/gm;
+    let match;
+    while ((match = regex.exec(existing)) !== null) {
+      existingSections.set(match[1], match[0]);
+    }
+  } catch {}
+
+  let out = `# Full Code Reference\n\n`;
+  out += `Includes source files from src, server, tests, lib, and scripts plus key config files. Excludes node_modules and build outputs.\n\n`;
+  out += `Regenerate with \`npm run docs:code:regen\`.\n\n`;
+  out += `## File Index\n\n`;
+  for (const f of files) out += `- ${f}\n`;
+  out += "\n";
+
+  for (const f of files) {
+    const content = (await fs.readFile(path.join(root, f), "utf8")).trimEnd();
+    const fence = fenceFor(f);
+    const block = `### ${f}\n\n\`\`\`${fence}\n${content}\n\`\`\`\n\n`;
+    const existing = existingSections.get(f);
+    out += existing && existing.trim() === block.trim() ? existing : block;
+  }
+  await fs.writeFile(outFile, out);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/generate_full_docs_reference.mjs
+++ b/scripts/generate_full_docs_reference.mjs
@@ -1,0 +1,48 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const docsDir = path.join(root, "docs");
+
+function isExcluded(rel) {
+  return (
+    rel.startsWith("exampleproject") ||
+    rel === "full_code_reference.md" ||
+    rel === "full_docs_reference.md"
+  );
+}
+
+async function collect(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    const rel = path.relative(docsDir, full);
+    if (entry.isDirectory()) {
+      if (!isExcluded(rel)) files.push(...(await collect(full)));
+    } else if (entry.isFile() && path.extname(entry.name) === ".md" && !isExcluded(rel)) {
+      files.push(rel);
+    }
+  }
+  return files;
+}
+
+async function main() {
+  await fs.mkdir(docsDir, { recursive: true });
+  const files = (await collect(docsDir)).sort();
+  let out = "# Full Docs Reference\n\n";
+  out += "Aggregated markdown documentation for this repository.\n";
+  out += "Regenerate with `npm run docs:docs:regen`.\n";
+  for (const f of files) {
+    const content = await fs.readFile(path.join(docsDir, f), "utf8");
+    out += `\n---\n# File: ${f}\n\n${content}\n`;
+  }
+  await fs.writeFile(path.join(docsDir, "full_docs_reference.md"), out);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Node scripts to aggregate code and docs references
- document local environment and usage
- register npm scripts for code and docs reference regeneration
- fix formatting in macOS libpq setup instructions

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_b_68b8a17b159083318121ec8fa275b6d2