### PR TITLE
Add QA Test General workflow for automated site checks

### DIFF
--- a/.github/workflows/qa-test-general.yml
+++ b/.github/workflows/qa-test-general.yml
@@ -1,0 +1,197 @@
+# This is the name of the workflow, which will be displayed in the GitHub Actions tab.
+name: QA Test General
+
+# Principle of least privilege for GITHUB_TOKEN
+permissions:
+  contents: read
+
+# Manual trigger only (no cron) to avoid costs and automatic runs
+on:
+  workflow_dispatch:
+    inputs:
+      url_offset:
+        description: 'Número de URLs a saltar (ej: 30 para analizar el siguiente lote)'
+        required: false
+        default: '0'
+
+# Ensure only one run at a time
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  # Job 1: Discover all internal URLs using a robust crawler.
+  discover-urls:
+    name: "Paso 1: Descubrir URLs (Crawler)"
+    runs-on: ubuntu-latest
+    outputs:
+      # The output is a JSON string array of URLs for consumption by matrix strategies.
+      url_matrix: ${{ steps.make_matrix.outputs.urls }}
+    steps:
+      - name: "Sanity check BASE_URL"
+        run: |
+          if [ -z "${{ vars.BASE_URL }}" ]; then
+            echo "Error: BASE_URL no está definida."
+            exit 1
+          fi
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: "Install and run Linkinator crawler"
+        run: npm install -g linkinator@4
+      - name: Ensure jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: "Crawl site, filter, and limit URLs"
+        id: crawl
+        env:
+          # Define MAX_URLS in Repo Settings > Secrets and Variables > Actions to control scope.
+          BASE: ${{ vars.BASE_URL }}
+          LIMIT: ${{ vars.MAX_URLS || 30 }}
+        run: |
+          set -e
+          # Lee parámetros
+          OFFSET=${{ github.event.inputs.url_offset || 0 }}
+          BASE_URL_NO_SLASH="${BASE%/}"
+          LIMIT="$LIMIT"
+
+          # Rastrea (no falla si encuentra links rotos)
+          linkinator "$BASE_URL_NO_SLASH" --recurse --silent --timeout 10000 --format JSON > crawl.json || true
+
+          # Si no se generó el JSON, crea uno vacío para que jq no falle
+          test -s crawl.json || echo '{"links":[]}' > crawl.json
+
+          # Rango del lote: [OFFSET+1 .. OFFSET+LIMIT]
+          START_LINE=$((OFFSET + 1))
+          END_LINE=$((OFFSET + LIMIT))
+
+          # Filtra internas, válidas y no-binarias; ordena y toma el lote
+          jq -r '.links[] | select(.status < 400) | .url' crawl.json \
+            | awk -v b="$BASE_URL_NO_SLASH" 'index($0,b)==1' \
+            | grep -Ev '\.(pdf|jpg|jpeg|png|gif|svg|webp|mp4|zip|rar|7z|gz|css|js|json|xml)$' \
+            | sort -u \
+            | sed -n "${START_LINE},${END_LINE}p" > urls.txt
+
+          # Pasa a JSON para la matriz
+          jq -Rs 'split("\n") | map(select(length>0))' urls.txt > urls.json
+      - name: "Prepare matrix for subsequent jobs"
+        id: make_matrix
+        run: echo "urls=$(cat urls.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload discovered URLs as artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: discovered-urls
+          path: urls.txt
+
+  # Lighthouse job, now powered by the matrix
+  lighthouse:
+    needs: discover-urls
+    if: needs.discover-urls.outputs.url_matrix != '[]' && needs.discover-urls.outputs.url_matrix != ''
+    name: "Test de Performance (Lighthouse)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        url: ${{ fromJson(needs.discover-urls.outputs.url_matrix || '[]') }}
+      fail-fast: false
+      max-parallel: 3 # Control concurrency
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install -g @lhci/cli
+      - name: "Run Lighthouse CI on ${{ matrix.url }}"
+        env:
+          LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.sha }}
+        run: |
+          lhci autorun \
+            --collect.url="${{ matrix.url }}" \
+            --collect.numberOfRuns=1 \
+            --upload.target=temporary-public-storage
+
+  # Pa11y job, now powered by the matrix
+  a11y:
+    needs: discover-urls
+    if: needs.discover-urls.outputs.url_matrix != '[]' && needs.discover-urls.outputs.url_matrix != ''
+    name: "Test de Accesibilidad (Pa11y)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    strategy:
+      matrix:
+        url: ${{ fromJson(needs.discover-urls.outputs.url_matrix || '[]') }}
+      fail-fast: false
+      max-parallel: 3 # Control concurrency
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install -g pa11y-ci pa11y-runner-axe
+      - name: "Run Pa11y on ${{ matrix.url }}"
+        run: |
+          URL="${{ matrix.url }}"
+          cat > pa11yci.json <<EOF
+          {
+            "defaults": {
+              "timeout": 30000,
+              "runners": ["axe"],
+              "chromeLaunchConfig": { "args": ["--no-sandbox","--disable-setuid-sandbox"] }
+            },
+            "urls": ["$URL"]
+          }
+          EOF
+          # A test that finds errors should fail the job to provide a clear signal.
+          pa11y-ci --config pa11yci.json
+
+  # ZAP Baseline scan (unchanged)
+  zap_baseline:
+    name: "Test de Seguridad Basico (ZAP)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: "Sanity check BASE_URL"
+        run: |
+          if [ -z "${{ vars.BASE_URL }}" ]; then
+            echo "Error: The BASE_URL variable is not defined."
+            exit 1
+          fi
+      - uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: "${{ vars.BASE_URL }}"
+          fail_action: false
+          allow_issue_writing: false
+
+  # WPScan using official Docker image (unchanged)
+  wpscan:
+    name: "Test de WordPress (WPScan)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: "Sanity check BASE_URL"
+        run: |
+          if [ -z "${{ vars.BASE_URL }}" ]; then
+            echo "Error: The BASE_URL variable is not defined."
+            exit 1
+          fi
+      - name: "Check if target is WordPress (and accessible)"
+        id: check_wp
+        run: |
+          BASE="${{ vars.BASE_URL }}"; BASE="${BASE%/}"
+          CODE=$(curl -sL -A "Mozilla/5.0" --retry 2 -o /tmp/index.html -w "%{http_code}" --max-time 15 "$BASE/" || echo "000")
+          if [ ! -s /tmp/index.html ]; then
+            echo "is_wordpress=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [ "$CODE" = "401" ] || [ "$CODE" = "403" ] || ! grep -qi 'wp-content' /tmp/index.html; then
+            echo "is_wordpress=false" >> $GITHUB_OUTPUT
+          else
+            echo "is_wordpress=true" >> $GITHUB_OUTPUT
+          fi
+      - name: "Run WPScan (official Docker image)"
+        if: steps.check_wp.outputs.is_wordpress == 'true' && secrets.WPSCAN_API_TOKEN != ''
+        run: |
+          docker run --rm wpscanteam/wpscan \
+            --url "${{ vars.BASE_URL }}" \
+            --stealthy \
+            --ignore-main-redirect \
+            --format cli \
+            --api-token "${{ secrets.WPSCAN_API_TOKEN }}"
+


### PR DESCRIPTION
## Summary
- add QA Test General workflow to crawl URLs then run Lighthouse, accessibility, ZAP, and WPScan checks
- support skipping a configurable number of discovered URLs with `url_offset`
- sanity-check `BASE_URL`, skip matrix jobs when no URLs, and install Pa11y axe runner
- guard Lighthouse/A11y jobs for empty URL matrices and run WPScan only when an API token is provided
- default matrix expansion to an empty array when no URLs are discovered and use `awk` for robust internal URL filtering
- ensure crawler always produces `crawl.json` and declare matrix job dependencies before conditional checks

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68b8c90ad488833192c312d5653c1b48